### PR TITLE
Fix incorrect PATH entry

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -129,7 +129,7 @@ fi									##
 umask 027								##
 									##
 #PATH="${PATH}:${HOME}/bin:."						##
-PATH="${PATH}:/usr/local/bin:/usr/share/perl/5.18.2/Getopt/Long.pm:."							##
+PATH="${PATH}:/usr/local/bin:."							##
 export PATH								##
 									##
 #MANPATH="${MANPATH}:${HOME}/man"					##


### PR DESCRIPTION
## Summary
- clean up the `PATH` variable in `.bashrc`
- keep `.` at the end of `PATH`

## Testing
- `bash -n .bashrc`


------
https://chatgpt.com/codex/tasks/task_e_6842aaf9fa68832dbaa9c2cb868864b8